### PR TITLE
Make toolchain extension mapping optional

### DIFF
--- a/cmake_file_api/kinds/toolchains/v1.py
+++ b/cmake_file_api/kinds/toolchains/v1.py
@@ -61,7 +61,7 @@ class CMakeToolchainCompiler(object):
 class CMakeToolchain(object):
     __slots__ = ("language", "compiler", "sourceFileExtensions")
 
-    def __init__(self, language: str, compiler: CMakeToolchainCompiler, sourceFileExtensions: List[str]):
+    def __init__(self, language: str, compiler: CMakeToolchainCompiler, sourceFileExtensions: Optional[List[str]]):
         self.language = language
         self.compiler = compiler
         self.sourceFileExtensions = sourceFileExtensions
@@ -70,7 +70,8 @@ class CMakeToolchain(object):
     def from_dict(cls, dikt: Dict) -> "CMakeToolchain":
         language = dikt["language"]
         compiler = CMakeToolchainCompiler.from_dict(dikt["compiler"])
-        sourceFileExtensions = dikt["sourceFileExtensions"]
+        sourceFileExtensions = dikt.get("sourceFileExtensions")
+
         return cls(language, compiler, sourceFileExtensions)
 
     def __repr__(self) -> str:

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -49,7 +49,8 @@ def simple_cxx_project(build_tree):
 def complex_cxx_project(build_tree):
     (build_tree.source / "CMakeLists.txt").write_text(textwrap.dedent("""\
         cmake_minimum_required(VERSION 3.0)
-        project(demoproject)
+        project(demoproject NONE)
+        enable_language(CXX)
         add_library(lib_noinstall lib1.cpp)
         add_library(lib_install lib1.cpp)
         install(TARGETS lib_install)


### PR DESCRIPTION
When compiling for an embedded target I noticed that languages that are not initialized in the project command may not have sourcefile mappings, but can still be present.
I was able to observe this behavior for both cmake `3.21.5` and `3.22.2`.

Both generate a toolchain object like this:
```
{
	"kind" : "toolchains",
	"toolchains" : 
	[
		// ... as expected asm compiler
		// ... as expected c compiler
		{
			"compiler" : 
			{
				"implicit" : {},
				"path" : "C:/Sle90ToolsRep/ARM/ARMCLANG/bin/armclang.exe"
			},
			"language" : "CXX"
		}
	],
	"version" : 
	{
		"major" : 1,
		"minor" : 0
	}
}
```
Regarding tests: would you like a test for this, looking at the existing one I think that might get a bit complicated. As far as I've seen I'd need to have a new project where I e.g. not enable CXX and provide a toolchain file that sets `CMAKE_CXX_COMPILER`.