### PR TITLE
Default source directory and cmake paths from CMakeCache.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                py: ['3.5', '3.6', '3.7', '3.8', '3.9']
+                py: ['3.6', '3.7', '3.8', '3.9', '3.10']
                 os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
         runs-on: ${{ matrix.os }}
         steps:

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.5",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
These values are stored as cache variables and, if the project has already been configured, are available in CMakeCache.txt.

See:
- https://cmake.org/cmake/help/latest/variable/CMAKE_HOME_DIRECTORY.html
- https://cmake.org/cmake/help/latest/variable/CMAKE_COMMAND.html

Note: I got breakages trying to run with Python 3.5. I dropped support (and added 3.10 to CI) instead of fixing them since it has been end-of-life for 2 years.