### PR TITLE
fix: get path of sysroot property in configureLog target

### DIFF
--- a/cmake_file_api/kinds/configureLog/target/v2.py
+++ b/cmake_file_api/kinds/configureLog/target/v2.py
@@ -348,7 +348,7 @@ class TargetCompileGroup(object):
         includes = list(TargetCompileGroupInclude.from_dict(tci, backtraceGraph) for tci in dikt.get("includes", ()))
         precompileHeaders = list(TargetCompileGroupPCH.from_dict(tcpch, backtraceGraph) for tcpch in dikt.get("precompileHeaders", ()))
         defines = list(TargetCompileGroupDefine.from_dict(tcdef, backtraceGraph) for tcdef in dikt.get("defines", ()))
-        sysroot = Path(dikt["sysroot"]) if "sysroot" in dikt else None
+        sysroot = Path(dikt["sysroot"]["path"]) if "sysroot" in dikt else None
         sources = list(target_sources[tsi] for tsi in dikt["sourceIndexes"])
         return cls(sources, language, compileCommandFragments, includes, precompileHeaders, defines, sysroot)
 


### PR DESCRIPTION
fixes another occurence that was missed by https://github.com/madebr/python-cmake-file-api/pull/15