### PR TITLE
remove typing extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.venv
 *.egg-info
 *.py[co]
+.idea

--- a/cmake_file_api/kinds/api.py
+++ b/cmake_file_api/kinds/api.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from typing import Protocol
-from typing_extensions import Self
 
 from .kind import ObjectKind
 from .cache.api import CACHE_API
@@ -14,7 +13,7 @@ class CMakeApiType(Protocol):
     KIND: ObjectKind
 
     @classmethod
-    def from_path(cls, path: Path, reply_path: Path) -> Self:
+    def from_path(cls, path: Path, reply_path: Path) -> "CMakeApiType":
         ...
 
 OBJECT_KINDS_API: dict[ObjectKind, dict[int, CMakeApiType]] = {


### PR DESCRIPTION
Hi @madebr , sorry about this. I missed removing this external import. In Python environments where `typing_extensions` is not installed via some other package dependency, cmake-file-api will break due to the undeclared dependency on typing-extensions.

In the CI dev environment the dependency was present due to the other packages needed for development, hence the pipeline was green.

I have removed the import again as it's not needed for correct typing.