### PR TITLE
fix ResourceWarning: unclosed file

### DIFF
--- a/cmake_file_api/kinds/cache/v2.py
+++ b/cmake_file_api/kinds/cache/v2.py
@@ -84,7 +84,8 @@ class CacheV2:
 
     @classmethod
     def from_path(cls, path: Path, reply_path: Path) -> "CacheV2":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt, reply_path)
 
     def __repr__(self) -> str:

--- a/cmake_file_api/kinds/cmakeFiles/v1.py
+++ b/cmake_file_api/kinds/cmakeFiles/v1.py
@@ -52,7 +52,8 @@ class CMakeFilesV1:
 
     @classmethod
     def from_path(cls, path: Path, reply_path: Path) -> "CMakeFilesV1":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt, reply_path)
 
     def __repr__(self) -> str:

--- a/cmake_file_api/kinds/codemodel/v2.py
+++ b/cmake_file_api/kinds/codemodel/v2.py
@@ -174,7 +174,8 @@ class CodemodelV2:
 
     @classmethod
     def from_path(cls, path: Path, reply_path: Path) -> "CodemodelV2":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt, reply_path)
 
     def get_configuration(self, name: str) -> CMakeConfiguration:

--- a/cmake_file_api/kinds/configureLog/v1.py
+++ b/cmake_file_api/kinds/configureLog/v1.py
@@ -27,7 +27,8 @@ class ConfigureLogV1:
 
     @classmethod
     def from_path(cls, path: Path, reply_path: Path) -> "ConfigureLogV1":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt, reply_path)
 
     def __repr__(self) -> str:

--- a/cmake_file_api/kinds/toolchains/v1.py
+++ b/cmake_file_api/kinds/toolchains/v1.py
@@ -99,7 +99,8 @@ class ToolchainsV1:
 
     @classmethod
     def from_path(cls, path: Path, reply_path: Path) -> "ToolchainsV1":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt, reply_path)
 
     def __repr__(self) -> str:

--- a/cmake_file_api/reply/index/v1.py
+++ b/cmake_file_api/reply/index/v1.py
@@ -157,5 +157,6 @@ class CMakeReplyFileV1:
 
     @classmethod
     def from_path(cls, path: Path) -> "CMakeReplyFileV1":
-        dikt = json.load(path.open())
+        with path.open() as file:
+            dikt = json.load(file)
         return cls.from_dict(dikt)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/builds/wN9wSB5rz/0/pes/infrastructure/general-libraries/python/pes-pip-vibe-cmake-interface/.venv/lib/python3.13/site-packages/cmake_file_api/kinds/codemodel/v2.py", line 177, in from_path
    dikt = json.load(path.open())
ResourceWarning: unclosed file <_io.TextIOWrapper name='.../tests/_temp/unit/test_cache_file_api.py/test_cache_file_api_codemodel/project/build/default/.cmake/api/v1/reply/codemodel-v2-c56a4e5771d35f723d81.json' mode='r' encoding='UTF-8'>
```